### PR TITLE
Bootcamp tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,15 +316,16 @@ gulp test
 Awesome. Now you know how to work with Gulp! Next, let's open up **app/scripts/main.js** in Atom and copy and paste your identity pool ID from Cognito. You can get this from the Cognito console.
 
 1. Find the variable **IDENTITY_POOL_ID** and update the variable with your identity pool.
-2. Go back to the command line and type:
+2. Find the variable **AWS.config.region** and update the variable with your region.
+3. Go back to the command line and type:
 ```
 gulp build
 ```
-3. Change the directory back to the main serverless directory and type:
+4. Change the directory back to the main serverless directory and type:
 ```
 sls client deploy
 ```
-4. Serverless will output an S3 link. Put that S3 link in your browser and check out your static site!!
+5. Serverless will output an S3 link. Put that S3 link in your browser and check out your static site!!
 
 ## Bringing it all together
 

--- a/client/app/scripts/main.js
+++ b/client/app/scripts/main.js
@@ -82,8 +82,8 @@ $( document ).ready(function() {
           console.log(err);
           return;
       }
-      var requestUrl = SigV4Utils.getSignedUrl('wss', 'data.iot.us-east-1.amazonaws.com', '/mqtt',
-          'iotdevicegateway', 'us-east-1',
+      var requestUrl = SigV4Utils.getSignedUrl('wss', 'data.iot.' + AWS.config.region + '.amazonaws.com', '/mqtt',
+          'iotdevicegateway', AWS.config.region,
           credentials.accessKeyId, credentials.secretAccessKey, credentials.sessionToken);
       initClient(requestUrl);
   });

--- a/device/sbs-simulator.js
+++ b/device/sbs-simulator.js
@@ -28,9 +28,9 @@ const options = commandLineArgs(optionDefinitions);
 var data = [];
 try {
   var device = awsIot.device({
-    keyPath: "cert/private.pem.key",
-    certPath: "cert/certificate.pem.crt",
-    caPath: "cert/root.pem.crt",
+    keyPath: "certs/private.pem.key",
+    certPath: "certs/certificate.pem.crt",
+    caPath: "certs/root.pem.crt",
     clientId: options.unitid,
     region: options.region
   });


### PR DESCRIPTION
This PR addresses a few issues I had in the bootcamp.

1. The Readme tells you to create a directory named `certs/` in the device simulator, but the directory there starts with `cert/`. 
2. Adds an extra step to the README to update another variable, `AWS.config.region`, in `main.js`
3. Substitute `AWS.config.region` in for hard coded regions in `main.js`