### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/cfn/kinesis/template.yaml
+++ b/cfn/kinesis/template.yaml
@@ -131,7 +131,7 @@ Resources:
       Role: { "Fn::GetAtt": [ LambdaFunctionExecutionRole, Arn ] }
       Timeout: { Ref: Timeout }
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       MemorySize: { Ref: MemorySize }
 
   Policy:

--- a/cfn/reset-api/template.yaml
+++ b/cfn/reset-api/template.yaml
@@ -87,7 +87,7 @@ Resources:
       Handler: index.handler
       Role:
         "Fn::GetAtt": [LambdaExecutionRole, Arn]
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
 
   LambdaExecutionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
CloudFormation templates in simplebeerservice have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.